### PR TITLE
Call command when doing Windows init.bat

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -99,7 +99,7 @@ Once you have cloned the Homestead repository, run the `bash init.sh` command fr
     bash init.sh
 
     // Windows...
-    init.bat
+    .\init.bat
 
 <a name="configuring-homestead"></a>
 ### Configuring Homestead


### PR DESCRIPTION
Getting errors when just copy/pasting from the documentation:

```
PS C:\env\homestead\box> init.bat
init.bat : The term 'init.bat' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ init.bat
+ ~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (init.bat:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException

Suggestion [3,General]: The command init.bat was not found, but does exist in the current location. Windows PowerShell does not load commands from the current location by default. If you trust this command, instead type: ".\init.bat". See "get-help about_Command_Precedence" for more details.
```

But if we use this instead:

```
PS C:\env\homestead\box> .\init.bat
        1 file(s) copied.
        1 file(s) copied.
        1 file(s) copied.
Homestead initialized!
```
