### PR TITLE
Use init command instead of init.sh it avoid confusion for Windows users

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -93,7 +93,7 @@ You should check out a tagged version of Homestead since the `master` branch may
     // Clone the desired release...
     git checkout v6.5.0
 
-Once you have cloned the Homestead repository, run the `bash init.sh` command from the Homestead directory to create the `Homestead.yaml` configuration file. The `Homestead.yaml` file will be placed in the Homestead directory:
+Once you have cloned the Homestead repository, run the init command from the Homestead directory to create the `Homestead.yaml` configuration file. The `Homestead.yaml` file will be placed in the Homestead directory:
 
     // Mac / Linux...
     bash init.sh


### PR DESCRIPTION
`bash init.sh` is only for Mac/Linux users. To avoid this confusing I would suggest calling it either it an "init command" or by changing it to "run the `bash init.sh` / `.\init.bat` command".